### PR TITLE
add alt text to images and change example university

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ create a workshop website.
 2.  On this page (<https://github.com/carpentries/workshop-template>),
     click on the green "Use this template" button (top right)
 
-    ![the 'use this template' button on GitHub](fig/select-github-use-template.png?raw=true)
+    ![screenshot of this repository's GitHub page with an arrow pointing to the the 'use this template' button on the top left](fig/select-github-use-template.png?raw=true)
 
 3.  Select the owner for your new repository.
     (This will probably be you, but may instead be an organization you belong to.)
 
 4.  Choose a name for your workshop website repository.
     This name should have the form `YYYY-MM-DD-site`,
-    e.g., `2016-12-01-miskatonic`,
+    e.g., `2016-12-01-oomza`,
     where `YYYY-MM-DD` is the start date of the workshop.
     If your workshop is held online, then the respository name should have `-online` in the end.
-    e.g., `2016-12-01-miskatonic-online`
+    e.g., `2016-12-01-oomza-online`
 
 5.  Make sure the repository is public, leave "Include all branches" unchecked, and click
 on "Create repository from template".
@@ -62,7 +62,7 @@ You will be redirected to your new copy of the workshop template respository.
 
 6. Your new website will be rendered at `https://your_username.github.io/YYYY-MM-DD-site`.
 For example, if your username is `gvwilson`, the website's URL will be
-`https://gvwilson.github.io/2016-12-01-miskatonic`.
+`https://gvwilson.github.io/2016-12-01-oomza`.
 
 If you experience a problem, please [get in touch](#getting-and-giving-help).
 
@@ -79,19 +79,19 @@ There are two ways of customizing your website. You can either:
     which will be at `https://github.com/your_username/YYYY-MM-DD-site`.
     For example,
     if your username is `gvwilson`,
-    the repository's URL will be `https://github.com/gvwilson/2016-12-01-miskatonic`.
+    the repository's URL will be `https://github.com/gvwilson/2016-12-01-oomza`.
 
 3.  Ensure you are on the gh-pages branch by clicking on the branch under the drop
     down in the menu bar (see the note below):
 
-    ![](fig/select-gh-pages-branch.png?raw=true)
+    ![screenshot of this repository's GitHub page showing the "Branch" dropdown menu expanded with the "gh-pages" branch selected](fig/select-gh-pages-branch.png?raw=true)
 
 3.  Edit the header of `index.md` to customize the list of instructors,
     workshop venue, etc.
     You can do this in the browser by clicking on it in the file view on GitHub
     and then selecting the pencil icon in the menu bar:
 
-    ![](fig/edit-index-file-menu-bar.png?raw=true)
+    ![screenshot of top menu bar for GitHub's file interface with the edit icon highlighted in the top right](fig/edit-index-file-menu-bar.png?raw=true)
 
     Editing hints are embedded in `index.md`,
     and full instructions are in [the customization instructions][customization].
@@ -154,8 +154,8 @@ make workshop-check
 ```
 
 Once you are satisfied with the edits to your site, commit and push the changes to your repository.
-A few minutes later, you can go to the GitHub Pages URL for your workshop site and preview it. In the example above, this is `https://gvwilson.github.io/2016-12-01-miskatonic`. The finished
-page should look [something like this](fig/completed-page.png?raw=true).
+A few minutes later, you can go to the GitHub Pages URL for your workshop site and preview it. In the example above, this is `https://gvwilson.github.io/2016-12-01-oomza`. [The finished
+page should look something like this](fig/completed-page.png?raw=true).
 
 
 ## Optional but Recommended Steps
@@ -171,9 +171,9 @@ No description, website, or topics provided. — Edit
 
 Click 'Edit' and add:
 
-1.  A very brief description of your workshop in the "Description" box (e.g., "Miskatonic University workshop, Dec. 2016")
+1.  A very brief description of your workshop in the "Description" box (e.g., "Oomza University workshop, Dec. 2016")
 
-2.  The URL for your workshop in the "Website" box (e.g., `https://gvwilson.github.io/2016-12-01-miskatonic`)
+2.  The URL for your workshop in the "Website" box (e.g., `https://gvwilson.github.io/2016-12-01-oomza`)
 
 This will help people find your website if they come to your repository's home page.
 


### PR DESCRIPTION
I apologise in advance for making two edits in one PR.

1. I have added alt text for the screenshots
2. I have changed "Miskatonic" to "Oomza"

Regarding point 2: For those unaware, Miskatonic is the fictional New England university created by HP Lovecraft, whose writings were _incredibly_ racist ([his image used to be the statue given for the World Fantasy Awards until 2015](https://www.theguardian.com/books/2015/nov/09/world-fantasy-award-drops-hp-lovecraft-as-prize-image)). In keeping with the tradition of having our example university names based on science fiction literature, I am borrowing "Oomza University" from [Nnedi Okorafor's wonderful "Binti" trilogy](https://nnedi.com/books/binti.html). Her writing is MUCH more relevant to our mission and values and I really like getting in the subtle pun of a University that takes students from all over the universe :alien: 